### PR TITLE
Fix dl-chem-101 link on resources page

### DIFF
--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -51,7 +51,7 @@ learning_resources:
 
   - title: "dl-chem-101"
     description: "Deep learning for chemistry educational repository"
-    url: "https://github.com/coleygroup/dl-chem-101"
+    url: "https://github.com/rociomer/dl-chem-101"
     category: "Education"
 
   - title: "AI4Chem"


### PR DESCRIPTION
Previous link leads to 404