### PR TITLE
Update Synformer pubs, carousel

### DIFF
--- a/_data/carousel.yml
+++ b/_data/carousel.yml
@@ -28,6 +28,12 @@
   link: https://www.nature.com/articles/s41586-025-09426-9#citeas
   date: 2025-08-20
 
+- title: SynFormer
+  description: Generative AI for navigating synthesizable chemical space
+  image: /images/carouselpic/synformer.png
+  link: https://doi.org/10.1073/pnas.2415665122
+  date: 2025-04-29
+
 - title: ContraScope
   description: Revealing the Relationship between Publication Bias and Chemical Reactivity with Contrastive Learning
   image: /images/carouselpic/contrascope.jpeg
@@ -45,12 +51,6 @@
   image: /images/carouselpic/diffms.png
   link: https://arxiv.org/abs/2502.09571
   date: 2025-02-13
-
-- title: SynFormer
-  description: Generative artificial intelligence for navigating synthesizable chemical space
-  image: /images/carouselpic/synformer.png
-  link: https://arxiv.org/abs/2410.03494
-  date: 2024-10-04
 
 - title: ShEPhERD
   description: Diffusing shape, electrostatics, and pharmacophores for bioisosteric drug design

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -31,6 +31,22 @@
 #     - metabolomics
 #     - data
 
+- title: "Generative AI for navigating synthesizable chemical space"
+  authors: Gao, W., Luo, S., Coley, C.W.
+  journal: Proc. Natl. Acad. Sci.
+  year: 2025
+  volume: 122
+  issue: 41
+  pages: e2415665122
+  url: https://doi.org/10.1073/pnas.2415665122
+  doi: 10.1073/pnas.2415665122
+  preprint: arXiv:2410.03494
+  preprint_url: https://doi.org/10.48550/arXiv.2410.03494
+  preprint_year: 2024
+  preprint_site: arxiv
+  themes:
+    - design and optimization
+
 - title: "Anomeric Selectivity of Glycosylations Through a Machine Learning Lens"
   authors: Faurschou, N.V., Friis, V., Raghavan, P., Pedersen, C.M., Coley, C.W.
   journal: J. Am. Chem. Soc.
@@ -437,18 +453,6 @@
   preprint_site: arxiv
   themes:
     - molecular representation
-    - design and optimization
-
-- title: "Generative artificial intelligence for navigating synthesizable chemical space"
-  authors: Gao, W., Luo, S., Coley, C.W.
-  journal: arXiv
-  year: 2024
-  url: https://doi.org/10.48550/arXiv.2410.03494
-  preprint: arXiv:2410.03494
-  preprint_url: https://doi.org/10.48550/arXiv.2410.03494
-  preprint_year: 2024
-  preprint_site: arxiv
-  themes:
     - design and optimization
 
 - title: "Ideation and evaluation of novel multicomponent reactions via mechanistic network analysis and automation"

--- a/_data/publications_blacklist.yml
+++ b/_data/publications_blacklist.yml
@@ -10,6 +10,7 @@ blacklisted_dois:
 blacklisted_arxiv_ids:
   - "2403.04580" # duplicate already in publications.yml
   - "2502.12979" # duplicate already in publications.yml
+  - "2410.03494" # duplicate already in publications.yml (changed title)
 
 blacklisted_titles:
   # Note: These are matched against normalized titles (lowercase, no punctuation)


### PR DESCRIPTION
- updated PNAS publication in publications.yml
- added arxiv id to banlist because name change from "Artificial Intelligence" -> "AI"
- updated carousel with correct link. set date to 4/29 (accepted date)